### PR TITLE
CameraMonitor: Decouple grabber calls to improve performance.

### DIFF
--- a/src/org/usfirst/frc/team2503/r2016/CameraMonitorTest.java
+++ b/src/org/usfirst/frc/team2503/r2016/CameraMonitorTest.java
@@ -1,5 +1,6 @@
 package org.usfirst.frc.team2503.r2016;
 
+import org.bytedeco.javacv.FrameGrabber.Exception;
 import org.usfirst.frc.team2503.r2016.data.DataServer;
 import org.usfirst.frc.team2503.r2016.input.vision.CameraMonitor;
 import org.usfirst.frc.team2503.websocket.WebSocket;
@@ -7,14 +8,20 @@ import org.usfirst.frc.team2503.websocket.WebSocket;
 public class CameraMonitorTest implements Runnable {
 
 	public DataServer ds;
-	
+
 	@Override
 	public void run() {
+		try {
+			CameraMonitor.start();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
 		while(true) {
 			String dataURI = "data:image/jpeg;base64," + CameraMonitor.getImageDataURIFromDevice();
-			
+
 			this.ds.put("image", dataURI);
-			
+
 			try {
 				Thread.sleep(100);
 			} catch (InterruptedException e) {
@@ -22,10 +29,10 @@ public class CameraMonitorTest implements Runnable {
 			}
 		}
 	}
-	
+
 	public CameraMonitorTest(DataServer ds) {
 		this.ds = ds;
 
 	}
-	
+
 }

--- a/src/org/usfirst/frc/team2503/r2016/Robot.java
+++ b/src/org/usfirst/frc/team2503/r2016/Robot.java
@@ -1,6 +1,8 @@
 package org.usfirst.frc.team2503.r2016;
 
 import org.usfirst.frc.team2503.r2016.data.DataServer;
+import org.usfirst.frc.team2503.r2016.input.vision.CameraMonitor;
+import org.usfirst.frc.team2503.r2016.subsystems.MainDriveBase;
 
 import edu.wpi.first.wpilibj.IterativeRobot;
 
@@ -9,6 +11,8 @@ public class Robot extends IterativeRobot {
 	public DataServer configurationServer;
 	public DataServer imageServer;
 	public DataServer dataServer;
+
+	public MainDriveBase driveBase;
 
 	public Robot() {
 		configurationServer = new DataServer(5800);
@@ -31,6 +35,9 @@ public class Robot extends IterativeRobot {
 	}
 
 	public void disabledPeriodic() {
+
+		System.out.println(CameraMonitor.getImageDataURIFromDevice());
+
 	}
 
 	public void autonomousInit() {

--- a/src/org/usfirst/frc/team2503/r2016/input/vision/CameraMonitor.java
+++ b/src/org/usfirst/frc/team2503/r2016/input/vision/CameraMonitor.java
@@ -43,55 +43,61 @@ public class CameraMonitor {
 	public static FrameGrabber grabber = new OpenCVFrameGrabber(1);
 	public static BufferedImage latestBufferedImage = null;
 	public static IplImage latestIplImage = null;
-	
+
 	public static OpenCVFrameConverter.ToIplImage grabberConverter = new OpenCVFrameConverter.ToIplImage();
 	public static Java2DFrameConverter paintConverter = new Java2DFrameConverter();
-	
-	public static void grabFrame() throws Exception {
+
+	public static void start() throws Exception {
 		grabber.start();
-		Frame frame = grabber.grabFrame();
+	}
+
+	public static void stop() throws Exception {
 		grabber.stop();
-		
+	}
+
+	public static void grabFrame() throws Exception {
+		Frame frame = grabber.grabFrame();
+
 		latestFrame = frame;
 	}
-	
+
 	public static void convertLatestFrameToBufferedImage() {
 		latestBufferedImage = paintConverter.getBufferedImage(latestFrame);
 	}
-	
+
 	public static void convertLatestFrameToIplImage() {
 		latestIplImage = grabberConverter.convert(latestFrame);
 	}
-	
+
 	public static String getImageDataURIFromDevice() {
 		try {
 			LocalTime t0 = LocalTime.now();
-			
+
 			grabFrame();
 
 			convertLatestFrameToBufferedImage();
 			// convertLatestFrameToIplImage();
 
 			BufferedImage newImage = new BufferedImage(128, 80, BufferedImage.TYPE_INT_RGB);
-			
+
 			Graphics g = newImage.createGraphics();
 			g.drawImage(latestBufferedImage, 0, 0, 128, 80, null);
 			g.dispose();
-			
+
 			File file = new File(Constants.HOME_DIRECTORY + "/capture.jpg");
 			File file2 = new File(Constants.HOME_DIRECTORY + "/capture2.jpg");
-			
+
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-						
+
 			ImageIO.write(latestBufferedImage, "jpg", file);
 			ImageIO.write(newImage, "jpg", baos);
 			ImageIO.write(newImage, "jpg", file2);
-			
+
 			LocalTime t1 = LocalTime.now();
-			
+
 			Duration duration = Duration.between(t0, t1);
 			System.out.println(duration.toMillis());
-			
+
 			return DatatypeConverter.printBase64Binary(baos.toByteArray());
 		} catch(IOException | Exception e) {
 			e.printStackTrace();
@@ -99,6 +105,6 @@ public class CameraMonitor {
 
 		return "";
 	}
-	
-	
+
+
 }


### PR DESCRIPTION
Instead of using a stupid technique and starting and stopping the frame grabber, just start it when the program starts and stop it when it stops.

See #5.
